### PR TITLE
Allow prime256v1 as a curve for ES256 JWT token. 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {NotificationPubSub} from './pubsub/notification-pub-sub'
 import AppLogger from './logger/app-logger'
 import {Container} from 'typedi'
 import {WebsocketServer} from './server/websocket-server'
+import process from 'process'
 
 declare module 'ws' {
   interface WebSocket {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import {NotificationPubSub} from './pubsub/notification-pub-sub'
 import AppLogger from './logger/app-logger'
 import {Container} from 'typedi'
 import {WebsocketServer} from './server/websocket-server'
-import process from 'process'
 
 declare module 'ws' {
   interface WebSocket {

--- a/src/server/websocket-server.ts
+++ b/src/server/websocket-server.ts
@@ -38,9 +38,11 @@ export class WebsocketServer {
 
     this.httpServer.on('upgrade', (request: IncomingMessage, socket: stream.Duplex, head: Buffer) => {
       try {
-        const userToken = verifyAuthorization(request)
+        const userToken = verifyAuthorization(request, this.appLogger)
         request.ssoUserId = userToken.sub
-      } catch {
+      } catch (error) {
+        this.appLogger.warn('Unauthorized attempt to connect.', error)
+
         socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n')
         socket.destroy()
 

--- a/src/util/user-token-verifier.ts
+++ b/src/util/user-token-verifier.ts
@@ -19,5 +19,6 @@ export function verifyAuthorization(request: IncomingMessage, logger: AppLogger)
 
   return jwt.verify(jwtRaw, Config.getJwtPublicKey(), {
     algorithms: [Config.getJwtAlgorithm()],
+    allowInvalidAsymmetricKeyTypes: true
   }) as IUserToken
 }

--- a/src/util/user-token-verifier.ts
+++ b/src/util/user-token-verifier.ts
@@ -3,8 +3,9 @@ import {Config} from '../config/config'
 import Cookies from 'cookies'
 import {IncomingMessage, ServerResponse} from 'http'
 import {IUserToken} from '../model/user-token'
+import AppLogger from '../logger/app-logger'
 
-export function verifyAuthorization(request: IncomingMessage): IUserToken {
+export function verifyAuthorization(request: IncomingMessage, logger: AppLogger): IUserToken {
   const cookies = new Cookies(request, new ServerResponse(request))
   const jwtRaw = Config.getJwtCookies()
     .map((cookieName) => cookies.get(cookieName))
@@ -13,6 +14,8 @@ export function verifyAuthorization(request: IncomingMessage): IUserToken {
   if (!jwtRaw || jwtPartsCount !== 2) {
     throw new Error('Invalid JWT token')
   }
+
+  logger.debug('Verifying authorization tokens...', { jwt: jwtRaw, pubCert: Config.getJwtPublicKey() })
 
   return jwt.verify(jwtRaw, Config.getJwtPublicKey(), {
     algorithms: [Config.getJwtAlgorithm()],


### PR DESCRIPTION
This because of https://github.com/auth0/node-jsonwebtoken/issues/862 